### PR TITLE
print docker version to stdOut instead of stdErr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,4 +103,4 @@ RUN apk add --no-cache alpine-baselayout ca-certificates bash curl procps
 
 COPY --from=build /usr/lib/jvm/graalvm /usr/lib/jvm/graalvm
 
-CMD java -version
+CMD java -version 2>&1


### PR DESCRIPTION
I know this is wrong, let's just open discussion here pls.
```
$ docker run --rm test/graal 2> errors.txt
openjdk version "11.0.6" 2020-01-14
OpenJDK Runtime Environment GraalVM CE 19.3.1 (build 11.0.6+9-jvmci-19.3-b07)
OpenJDK 64-Bit Server VM GraalVM CE 19.3.1 (build 11.0.6+9-jvmci-19.3-b07, mixed mode, sharing)

$ cat errors.txt

```
Unfortunately `java -version` prints to stdErr which is stupid ... the problem is that for instance Stackdriver treats it as `severity=ERROR`